### PR TITLE
Fix display on RTL websites

### DIFF
--- a/superselector/style.css
+++ b/superselector/style.css
@@ -1,4 +1,5 @@
 .superselect {
+	direction: ltr;
 	height:120px;
 	width:600px;
 	z-index:99999;


### PR DESCRIPTION
SuperSelector doesn't look right on sites with rtl direction:
![image](https://cloud.githubusercontent.com/assets/2012892/5059151/b13196de-6d18-11e4-9ea6-d808cd43be3a.png)
Adding 'direction: ltr' on the main container element fixes this.
